### PR TITLE
Fix money parsing for comma formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:money": "node scripts/normalizeMoneyTest.cjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/normalizeMoneyTest.cjs
+++ b/scripts/normalizeMoneyTest.cjs
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const normalizeMoney = s => {
+  if (s.includes(',') && s.includes('.')) {
+    if (s.lastIndexOf(',') > s.lastIndexOf('.')) {
+      s = s.replace(/\./g, '').replace(',', '.');
+    } else {
+      s = s.replace(/,/g, '');
+    }
+  } else if (s.includes(',')) {
+    s = s.replace(/\./g, '').replace(',', '.');
+  } else {
+    s = s.replace(/,/g, '');
+  }
+  return parseFloat(s);
+};
+
+assert.strictEqual(normalizeMoney('1.234,56'), 1234.56);
+assert.strictEqual(normalizeMoney('1234.56'), 1234.56);
+assert.strictEqual(normalizeMoney('1,234.56'), 1234.56);
+
+console.log('All tests passed');

--- a/src/components/workflow/ConciergeChat.tsx
+++ b/src/components/workflow/ConciergeChat.tsx
@@ -7,6 +7,22 @@ import { ConciergeRequest, ConciergeResponse, Citation } from "@/types/workflow"
 import { Send, Bot, User, FileText, ExternalLink, Brain } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+// Normalize monetary strings like "1.234,56" or "1,234.56"
+const normalizeMoney = (s: string) => {
+  if (s.includes(',') && s.includes('.')) {
+    if (s.lastIndexOf(',') > s.lastIndexOf('.')) {
+      s = s.replace(/\./g, '').replace(',', '.');
+    } else {
+      s = s.replace(/,/g, '');
+    }
+  } else if (s.includes(',')) {
+    s = s.replace(/\./g, '').replace(',', '.');
+  } else {
+    s = s.replace(/,/g, '');
+  }
+  return parseFloat(s);
+};
+
 interface ConciergeChatProps {
   onAgentSuggestion?: (agentId: string) => void;
   onDataExtraction?: (data: Record<string, any>) => void;
@@ -117,7 +133,7 @@ export const ConciergeChat: React.FC<ConciergeChatProps> = ({
     
     const valueMatch = message.match(/R\$\s*([\d.,]+)/);
     if (valueMatch) {
-      data.estimatedValue = parseFloat(valueMatch[1].replace(',', ''));
+      data.estimatedValue = normalizeMoney(valueMatch[1]);
     }
     
     if (message.toLowerCase().includes('auto')) {

--- a/src/services/conciergeOrchestrator.ts
+++ b/src/services/conciergeOrchestrator.ts
@@ -6,6 +6,22 @@
 import { workflowEngine } from './workflowEngine';
 import { WorkflowExecution } from '@/types/workflow';
 
+// Helper to normalize monetary strings like "1.234,56" or "1,234.56"
+const normalizeMoney = (s: string) => {
+  if (s.includes(',') && s.includes('.')) {
+    if (s.lastIndexOf(',') > s.lastIndexOf('.')) {
+      s = s.replace(/\./g, '').replace(',', '.');
+    } else {
+      s = s.replace(/,/g, '');
+    }
+  } else if (s.includes(',')) {
+    s = s.replace(/\./g, '').replace(',', '.');
+  } else {
+    s = s.replace(/,/g, '');
+  }
+  return parseFloat(s);
+};
+
 export interface TaskContext {
   id: string;
   originalQuery: string;
@@ -181,7 +197,7 @@ class ConciergeOrchestrator {
     // Extrai valores monetários
     const moneyMatch = query.match(/R\$\s*([\d.,]+)/);
     if (moneyMatch) {
-      data.valor_estimado = parseFloat(moneyMatch[1].replace(',', ''));
+      data.valor_estimado = normalizeMoney(moneyMatch[1]);
     }
     
     // Extrai datas


### PR DESCRIPTION
## Summary
- add `normalizeMoney` utility to handle comma decimals and thousands separators
- use `normalizeMoney` when extracting money amounts
- provide manual test to verify money parsing works on different locales

## Testing
- `npm run test:money`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6873f546a22483258eb6487eaa7365b9