### PR TITLE
Add sidebar toggle button to header

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/AppSidebar";
 import { Footer } from "@/components/Footer";
 import { TenantHeader } from "@/components/tenant/TenantHeader";

--- a/src/components/tenant/TenantHeader.tsx
+++ b/src/components/tenant/TenantHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTenant } from '@/contexts/TenantContext';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Building2, LogOut, Settings, User } from 'lucide-react';
@@ -21,6 +22,7 @@ export const TenantHeader: React.FC = () => {
       <div className="flex h-16 items-center justify-between px-6">
         {/* Logo e nome do tenant */}
         <div className="flex items-center space-x-3">
+          <SidebarTrigger />
           <div className="w-8 h-8 bg-primary/10 rounded-lg flex items-center justify-center">
             <Building2 className="w-5 h-5 text-primary" />
           </div>


### PR DESCRIPTION
## Summary
- use `SidebarTrigger` inside `TenantHeader`
- remove unused import from `Layout`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68741b2a8e088325b632673db4ee6266